### PR TITLE
Refactor message provider

### DIFF
--- a/config/webpack.test.js
+++ b/config/webpack.test.js
@@ -10,7 +10,7 @@
           {
               test: /\.ts$/,
               loaders: ['awesome-typescript-loader']
-          },
+          }
         ]
     }
-}
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ export class DefaultErrorMessages {
     unknownError: string;
     rangeLength: string;
     range: string;
+    [key: string]: string;
 }
 
 export const defaultConfig: ValidationMessagesConfiguration = {

--- a/src/message-provider.ts
+++ b/src/message-provider.ts
@@ -38,19 +38,15 @@ export class MessageProvider {
 
             default:
                 // TODO: Test this
-                if (errorPayload.message) {
-                    let placeholderValues: any[] = [];
-
-                    for (let key in errorPayload) {
-                        if (key !== 'message') {
-                            placeholderValues.push(errorPayload[key]);
-                        }
-                    }
-
-                    return this._stringFormat(errorPayload.message, placeholderValues);
-                } else {
+                if (!errorPayload.message) {
                     return this.defaultMessages.unknownError;
                 }
+
+                let placeholderValues: any[] = Object.keys(errorPayload)
+                    .filter(key => key !== 'message')
+                    .map(key => errorPayload[key]);
+
+                return this._stringFormat(errorPayload.message, placeholderValues);
         }
     }
 

--- a/src/message-provider.ts
+++ b/src/message-provider.ts
@@ -37,7 +37,6 @@ export class MessageProvider {
                 return this._stringFormat(errorMessageActual, [errorPayload.rangeMin, errorPayload.rangeMax]);
 
             default:
-                // TODO: Test this
                 if (!errorPayload.message) {
                     return this.defaultMessages.unknownError;
                 }

--- a/src/message-provider.ts
+++ b/src/message-provider.ts
@@ -12,37 +12,29 @@ export class MessageProvider {
      * @param errorPayload Provides custom message and/or the required value. E.g. for ValidationExtensions.minNumber(18) the payload will contain the value "18"
      */
     getErrorMessage(errorType: string, errorPayload: any): string {
+        let errorMessageActual = errorPayload.message || this.defaultMessages[errorType];
+
         // TODO: Throw exception on inadequate errorPayload;
         switch (errorType) {
             case 'required':
-                return errorPayload.message ? errorPayload.message : this.defaultMessages.required;
-
             case 'email':
-                return errorPayload.message ? errorPayload.message : this.defaultMessages.email;
+            case 'pattern':
+            case 'noEmpty':
+                return errorMessageActual;
 
             case 'minlength':
-                return errorPayload.message ? this._stringFormat(errorPayload.message, errorPayload.requiredLength) : this._stringFormat(this.defaultMessages.minLength, errorPayload.requiredLength);
+                return this._stringFormat(errorMessageActual || this.defaultMessages.minLength, errorPayload.requiredLength);
 
             case 'maxlength':
-                return errorPayload.message ? this._stringFormat(errorPayload.message, errorPayload.requiredLength) : this._stringFormat(this.defaultMessages.maxLength, errorPayload.requiredLength);
+                return this._stringFormat(errorMessageActual || this.defaultMessages.maxLength, errorPayload.requiredLength);
 
             case 'minNumber':
-                return errorPayload.message ? this._stringFormat(errorPayload.message, errorPayload.requiredRange) : this._stringFormat(this.defaultMessages.minNumber, errorPayload.requiredRange);
-
             case 'maxNumber':
-                return errorPayload.message ? this._stringFormat(errorPayload.message, errorPayload.requiredRange) : this._stringFormat(this.defaultMessages.maxNumber, errorPayload.requiredRange);
-
-            case 'pattern':
-                return errorPayload.message ? errorPayload.message : this.defaultMessages.pattern;
-
-            case 'noEmpty':
-                return errorPayload.message ? errorPayload.message : this.defaultMessages.noEmpty;
+                return this._stringFormat(errorMessageActual, errorPayload.requiredRange);
 
             case 'rangeLength':
-                return errorPayload.message ? this._stringFormat(errorPayload.message, [errorPayload.rangeMin, errorPayload.rangeMax]) : this._stringFormat(this.defaultMessages.rangeLength, [errorPayload.rangeMin, errorPayload.rangeMax]);
-
             case 'range':
-                return errorPayload.message ? this._stringFormat(errorPayload.message, [errorPayload.rangeMin, errorPayload.rangeMax]) : this._stringFormat(this.defaultMessages.range, [errorPayload.rangeMin, errorPayload.rangeMax]);
+                return this._stringFormat(errorMessageActual, [errorPayload.rangeMin, errorPayload.rangeMax]);
 
             default:
                 // TODO: Test this

--- a/tests/message-provider.spec.ts
+++ b/tests/message-provider.spec.ts
@@ -1,4 +1,4 @@
-﻿import { defaultConfig, DefaultErrorMessages } from '../src/config';
+﻿import { defaultConfig } from '../src/config';
 import { MessageProvider } from '../src/message-provider';
 
 const messageProvider = new MessageProvider(defaultConfig.defaultErrorMessages);
@@ -50,7 +50,7 @@ describe('Testing The Message Provider', () => {
             expect(actual).toEqual(expected);
         });
 
-        it('should return default message empty', () => {
+        it('should return default message empty payload', () => {
             let actual = messageProvider.getErrorMessage('email', '');
             let expected = defaultConfig.defaultErrorMessages.email;
 
@@ -79,7 +79,7 @@ describe('Testing The Message Provider', () => {
             expect(actual).toEqual(expected);
         });
 
-        it('should return default message empty', () => {
+        it('should return default message empty payload', () => {
             let actual = messageProvider.getErrorMessage('pattern', '');
             let expected = defaultConfig.defaultErrorMessages.pattern;
 
@@ -108,7 +108,7 @@ describe('Testing The Message Provider', () => {
             expect(actual).toEqual(expected);
         });
 
-        it('should return default message empty', () => {
+        it('should return default message empty payload', () => {
             let actual = messageProvider.getErrorMessage('noEmpty', '');
             let expected = defaultConfig.defaultErrorMessages.noEmpty;
 
@@ -130,7 +130,7 @@ describe('Testing The Message Provider', () => {
             }).toThrow();
         });
 
-        it('should return default message when boolean', () => {
+        it('should return default message when payload without message', () => {
             let actual = messageProvider.getErrorMessage('minlength', { requiredLength: 3 });
             let expected = stringFormat(defaultConfig.defaultErrorMessages.minLength, 3);
 
@@ -152,7 +152,7 @@ describe('Testing The Message Provider', () => {
             }).toThrow();
         });
 
-        it('should return default message when boolean', () => {
+        it('should return default message when payload without message', () => {
             let actual = messageProvider.getErrorMessage('maxlength', { requiredLength: 3 });
             let expected = stringFormat(defaultConfig.defaultErrorMessages.maxLength, 3);
 
@@ -174,7 +174,7 @@ describe('Testing The Message Provider', () => {
             }).toThrow();
         });
 
-        it('should return default message when boolean', () => {
+        it('should return default message when payload without message', () => {
             let actual = messageProvider.getErrorMessage('minNumber', { requiredRange: 3 });
             let expected = stringFormat(defaultConfig.defaultErrorMessages.minNumber, 3);
 
@@ -196,7 +196,7 @@ describe('Testing The Message Provider', () => {
             }).toThrow();
         });
 
-        it('should return default message when boolean', () => {
+        it('should return default message when payload without message', () => {
             let actual = messageProvider.getErrorMessage('maxNumber', { requiredRange: 3 });
             let expected = stringFormat(defaultConfig.defaultErrorMessages.maxNumber, 3);
 
@@ -218,11 +218,9 @@ describe('Testing The Message Provider', () => {
             }).toThrow();
         });
 
-        it('should return default message whit data', () => {
+        it('should return default message with data', () => {
             let actual = messageProvider.getErrorMessage('rangeLength', { rangeMin: 5, rangeMax: 10 });
             let expected = stringFormat(defaultConfig.defaultErrorMessages.rangeLength, [5, 10]);
-
-            console.log(actual);
 
             expect(actual).toEqual(expected);
         });
@@ -230,8 +228,6 @@ describe('Testing The Message Provider', () => {
         it('should return custom message', () => {
             let actual = messageProvider.getErrorMessage('rangeLength', { message: CUSTOM_MESSAGE_WITH_MORE_PLACEHOLDERS, rangeMin: 5, rangeMax: 10 });
             let expected = stringFormat(CUSTOM_MESSAGE_WITH_MORE_PLACEHOLDERS, [5, 10]);
-
-            console.log(actual);
 
             expect(actual).toEqual(expected);
         });
@@ -244,11 +240,9 @@ describe('Testing The Message Provider', () => {
             }).toThrow();
         });
 
-        it('should return default message whit data', () => {
+        it('should return default message with data', () => {
             let actual = messageProvider.getErrorMessage('range', { rangeMin: 5, rangeMax: 10 });
             let expected = stringFormat(defaultConfig.defaultErrorMessages.range, [5, 10]);
-
-            console.log(actual);
 
             expect(actual).toEqual(expected);
         });
@@ -257,14 +251,41 @@ describe('Testing The Message Provider', () => {
             let actual = messageProvider.getErrorMessage('range', { message: CUSTOM_MESSAGE_WITH_MORE_PLACEHOLDERS, rangeMin: 5, rangeMax: 10 });
             let expected = stringFormat(CUSTOM_MESSAGE_WITH_MORE_PLACEHOLDERS, [5, 10]);
 
-            console.log(actual);
+            expect(actual).toEqual(expected);
+        });
+    });
+
+    describe('Testing unexisting error messages', () => {
+        it('should throw error when null payload', () => {
+            expect(function () {
+                messageProvider.getErrorMessage(null, null);
+            }).toThrow();
+        });
+
+        it('should return default message when empty payload', () => {
+            let actual = messageProvider.getErrorMessage('unexisting', '');
+            let expected = stringFormat(defaultConfig.defaultErrorMessages.unknownError);
+
+            expect(actual).toEqual(expected);
+        });
+
+        it('should return default message when payload without message', () => {
+            let actual = messageProvider.getErrorMessage('unexisting', {});
+            let expected = stringFormat(defaultConfig.defaultErrorMessages.unknownError);
+
+            expect(actual).toEqual(expected);
+        });
+
+        it('should return custom message', () => {
+            let actual = messageProvider.getErrorMessage('unexisting', { message: CUSTOM_MESSAGE_WITH_MORE_PLACEHOLDERS, rangeMin: 5, rangeMax: 10 });
+            let expected = stringFormat(CUSTOM_MESSAGE_WITH_MORE_PLACEHOLDERS, [5, 10]);
 
             expect(actual).toEqual(expected);
         });
     });
 });
 
-function stringFormat(text: string, params: any): string {
+function stringFormat(text: string, params?: any): string {
     if (params) {
         if (!Array.isArray(params)) {
             params = [params];


### PR DESCRIPTION
- Remove repeated code in MessageProvider.getErrorMessage case statements
- Add unit tests for the default case in MessageProvider.getErrorMessage
