### PR TITLE
Change to be able to override a single error message

### DIFF
--- a/src/messages.component.ts
+++ b/src/messages.component.ts
@@ -22,7 +22,8 @@ export class ValidationMessageComponent implements OnInit {
             this.config = Object.assign({}, defaultConfig, customConfig);
         }
 
-        this.messageProvider = new MessageProvider(this.config.defaultErrorMessages);
+        const errorMessages = Object.assign({}, defaultConfig.defaultErrorMessages, this.config.defaultErrorMessages);
+        this.messageProvider = new MessageProvider(errorMessages);
     }
 
     ngOnInit(): void {


### PR DESCRIPTION
I noticed that when I define a ```defaultErrorMessages``` object in the config, I have to specify all possible error messages with a custom message. If I don't, this causes an error because the error message obviously doesn't exist and thus placeholders can't be replaced further on in the code.

As I didn't want to specify _all_ error messages and just wanted to override a single message, I created this pull request that made this possible 😊 